### PR TITLE
Fix undefined memory access

### DIFF
--- a/power.c
+++ b/power.c
@@ -77,7 +77,7 @@ fixed fix_exp(fixed op1) {
    * guaranteed bit-accurate taylor series approximation (at least in a fix_internal).
    */
 
-#define FIX_EXP_LOOP 26
+#define FIX_EXP_LOOP 25
 
   /* To generate the table of fractional bits vs. loop iterations:
    *


### PR DESCRIPTION
In lut.h, LUT_int_inv_integer is defined with size 25, but the current code attempts to access element 25. 

This PR simply changes the number of loop iterations in fix_exp() to 25, which does not seem to be an issue since all tests continue to pass. 